### PR TITLE
(fix): Generics on Enums

### DIFF
--- a/generator/src/main/java/us/hebi/quickbuf/generator/EnumGenerator.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/EnumGenerator.java
@@ -42,7 +42,7 @@ class EnumGenerator {
 
     TypeSpec generate() {
         TypeSpec.Builder type = TypeSpec.enumBuilder(info.getTypeName())
-                .addSuperinterface(RuntimeClasses.ProtoEnum)
+                .addSuperinterface(ParameterizedTypeName.get(RuntimeClasses.ProtoEnum, info.getTypeName()))
                 .addModifiers(PUBLIC);
 
         // Add enum constants

--- a/generator/src/main/java/us/hebi/quickbuf/generator/FieldGenerator.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/FieldGenerator.java
@@ -710,11 +710,11 @@ public class FieldGenerator {
         m.put("field", info.getFieldName());
         m.put("default", info.getDefaultValue());
         if (info.isEnum()) {
-			m.put("default", info.hasDefaultValue() ? info.getTypeName() + "." + info.getDefaultValue() + "_VALUE" : "0");
-			m.put("defaultEnumValue", info.getTypeName() + "." + info.getDefaultValue());
-			m.put("protoEnum", ParameterizedTypeName.get(RuntimeClasses.ProtoEnum, info.getTypeName()));
+          m.put("default", info.hasDefaultValue() ? info.getTypeName() + "." + info.getDefaultValue() + "_VALUE" : "0");
+          m.put("defaultEnumValue", info.getTypeName() + "." + info.getDefaultValue());
+          m.put("protoEnum", ParameterizedTypeName.get(RuntimeClasses.ProtoEnum, info.getTypeName()));
 		} else {
-			m.put("protoEnum", RuntimeClasses.ProtoEnum);
+          m.put("protoEnum", RuntimeClasses.ProtoEnum);
 		}
         m.put("storeType", storeType);
         m.put("commentLine", info.getJavadoc());
@@ -749,7 +749,6 @@ public class FieldGenerator {
         m.put("protoSource", RuntimeClasses.ProtoSource);
         m.put("protoSink", RuntimeClasses.ProtoSink);
         m.put("protoUtil", RuntimeClasses.ProtoUtil);
-        m.put("protoEnum", RuntimeClasses.ProtoEnum);
 
         // Common configuration-dependent code blocks
         clearOtherOneOfs = generateClearOtherOneOfs();

--- a/generator/src/main/java/us/hebi/quickbuf/generator/FieldGenerator.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/FieldGenerator.java
@@ -710,9 +710,12 @@ public class FieldGenerator {
         m.put("field", info.getFieldName());
         m.put("default", info.getDefaultValue());
         if (info.isEnum()) {
-            m.put("default", info.hasDefaultValue() ? info.getTypeName() + "." + info.getDefaultValue() + "_VALUE" : "0");
-            m.put("defaultEnumValue", info.getTypeName() + "." + info.getDefaultValue());
-        }
+			m.put("default", info.hasDefaultValue() ? info.getTypeName() + "." + info.getDefaultValue() + "_VALUE" : "0");
+			m.put("defaultEnumValue", info.getTypeName() + "." + info.getDefaultValue());
+			m.put("protoEnum", ParameterizedTypeName.get(RuntimeClasses.ProtoEnum, info.getTypeName()));
+		} else {
+			m.put("protoEnum", RuntimeClasses.ProtoEnum);
+		}
         m.put("storeType", storeType);
         m.put("commentLine", info.getJavadoc());
         m.put("getMutableMethod", info.getMutableGetterName());


### PR DESCRIPTION
Consider the following proto file:

```proto
syntax = "proto3";

package foo;

option java_multiple_files = true;

enum CurrencyType {
    USD = 0;
    BRL = 1;
}

message Value {
    uint32 decimal = 1;
    uint32 cents = 2;
    CurrencyType type = 3;
}
```

The generated enum implements ProtoEnum with no type, but its associated converter is typed:

```java
public enum CurrencyType implements ProtoEnum {
...
  enum CurrencyTypeConverter implements ProtoEnum.EnumConverter<CurrencyType> {
    INSTANCE;
  }

}
```

This leads to compiler issues at JsonSource::readEnum call sites. Excerpt for mergeFrom

```java
 case 3575610: {
          if (input.isAtField(FieldNames.type)) {
            if (!input.trySkipNullValue()) {
              final ProtoEnum value = input.readEnum(CurrencyType.converter()); // compiler error on eclipse
              if (value != null) {
                type = value.getNumber();
                bitField0_ |= 0x00000004;
              } else {
                input.skipUnknownEnumValue();
              }
            }
          } else {
            input.skipUnknownField();
          }
          break;
        }
```

Either the converter should be implemented as a raw type or enum should not implement ProtoMessage as a raw type.
