### PR TITLE
Added descriptor API

### DIFF
--- a/generator/native-release/Readme.md
+++ b/generator/native-release/Readme.md
@@ -25,7 +25,7 @@ Given that Maven releases can only be released once, we decided to add some manu
 * cd into `generator/native-release`
 * copy the workflow artifact executables into `bin/`
 * set the appropriate `<version>` in the `pom.xml`
-* `mvn clean deploy`
+* `mvn clean deploy -Prelease`
 
 ### Releasing to Github
 

--- a/generator/native-release/pom.xml
+++ b/generator/native-release/pom.xml
@@ -26,13 +26,13 @@
             <!-- download protoc for building the site (bundled with Conveyor) -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>download-protoc</id>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <tasks>
+                            <target>
 
                                 <!-- download proto compiler for all OS -->
                                 <mkdir dir="protoc"/>
@@ -47,7 +47,7 @@
                                 <!-- add executable bit for the plugin -->
                                 <chmod file="bin/**.exe" perm="775" type="both"/>
 
-                            </tasks>                            <testSourceRoot>target/generated-test-sources</testSourceRoot>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -63,13 +63,13 @@
             <!-- Generate sample compiler plugin requests that we can work with in unit tests -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>generate-test-sources</id>
                         <phase>generate-test-sources</phase>
                         <configuration>
-                            <tasks>
+                            <target>
 
                                 <!-- download proto compiler if needed -->
                                 <mkdir dir="${protoc.path}"/>
@@ -142,8 +142,7 @@
                                     <arg value="--proto_path=${proto.dir.unsupported}/"/>
                                     <arg value="${proto.dir.unsupported}/proto3.proto"/>
                                 </exec>
-                            </tasks>
-                            <testSourceRoot>target/generated-test-sources</testSourceRoot>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>
@@ -180,7 +179,7 @@
             <!-- Add scripts that can be executed by protoc -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-plugin-scripts</id>
@@ -189,7 +188,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <!-- Windows Script-->
                                 <mkdir dir="target"/>
                                 <copy file="src/main/scripts/windows.bat" tofile="target/${protocPluginName}.bat"/>
@@ -201,7 +200,7 @@
                                 <replace file="target/${protocPluginName}" token="{jarfile}" value="${finalName}"/>
                                 <fixcrlf file="target/${protocPluginName}" eol="unix"/>
                                 <chmod file="target/${protocPluginName}" perm="775" type="file"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/generator/src/main/java/us/hebi/quickbuf/generator/CompilerPlugin.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/CompilerPlugin.java
@@ -96,8 +96,12 @@ public class CompilerPlugin {
                 list.accept(new MessageGenerator(type).generate());
             }
 
+            if (file.isGenerateDescriptors()) {
+                new DescriptorGenerator(file).generate(outerClassSpec);
+            }
+
             // Omitt completely empty outer classes
-            if (!file.isGenerateMultipleFiles()) {
+            if (file.isGenerateDescriptors() || !file.isGenerateMultipleFiles()) {
                 topLevelTypes.add(outerClassSpec.build());
             }
 

--- a/generator/src/main/java/us/hebi/quickbuf/generator/DescriptorGenerator.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/DescriptorGenerator.java
@@ -1,0 +1,220 @@
+/*-
+ * #%L
+ * quickbuf-generator
+ * %%
+ * Copyright (C) 2019 - 2023 HEBI Robotics
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package us.hebi.quickbuf.generator;
+
+import com.google.protobuf.DescriptorProtos;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.lang.model.element.Modifier;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+
+/**
+ * @author Florian Enner
+ * @since 21 Sep 2023
+ */
+class DescriptorGenerator {
+
+    static String getDescriptorBytesFieldName() {
+        return "descriptorBytes";
+    }
+
+    static String getFileDescriptorFieldName() {
+        return "descriptor";
+    }
+
+    static String getDescriptorFieldName(RequestInfo.MessageInfo info) {
+        // unique name that matches the protobuf-java convention
+        String name = info.getTypeId().replaceAll("\\.", "_");
+        return "internal_static" + name + "_descriptor";
+    }
+
+    public void generate(TypeSpec.Builder type) {
+
+        // bytes shared by everything
+        type.addField(FieldSpec.builder(RuntimeClasses.BytesType, getDescriptorBytesFieldName())
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                .initializer(generateEmbeddedByteBlock(fileDescriptorBytes))
+                .build());
+
+        // field for the main file descriptor
+        CodeBlock.Builder initBlock = CodeBlock.builder();
+        initBlock.add("new $T($S, $S, $N", RuntimeClasses.FileDescriptor,
+                info.getDescriptor().getName(),
+                info.getDescriptor().getPackage(),
+                getDescriptorBytesFieldName());
+
+        // any file dependencies
+        if (info.getDescriptor().getDependencyCount() > 0) {
+            for (String fileName : info.getDescriptor().getDependencyList()) {
+                initBlock.add(", $T.getDescriptor()", info.getParentRequest().getInfoForFile(fileName).getOuterClassName());
+            }
+        }
+        initBlock.add(")");
+
+        FieldSpec fileDescriptor = FieldSpec.builder(RuntimeClasses.FileDescriptor, getFileDescriptorFieldName())
+                .addModifiers(Modifier.STATIC, Modifier.FINAL)
+                .initializer(initBlock.build())
+                .build();
+        type.addField(fileDescriptor);
+
+        // Add a static method
+        type.addMethod(MethodSpec.methodBuilder("getDescriptor")
+                .addJavadoc("@return this proto file's descriptor.")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(RuntimeClasses.FileDescriptor)
+                .addStatement("return $N", getFileDescriptorFieldName())
+                .build());
+
+        // Descriptor field for each nested type. The message protos should
+        // be serialized sequentially, so we start the next search offset where
+        // the last descriptor ended.
+        int offset = 0;
+        for (RequestInfo.MessageInfo message : info.getMessageTypes()) {
+            offset = addMessageDescriptor(type, message, offset);
+        }
+
+    }
+
+    private int addMessageDescriptor(TypeSpec.Builder type, RequestInfo.MessageInfo message, int startOffset) {
+        DescriptorProtos.DescriptorProto msgDesc = message.getDescriptor();
+        byte[] descriptorBytes = message.getDescriptor().toByteArray();
+
+        final int offset = findOffset(fileDescriptorBytes, descriptorBytes, startOffset);
+        final int length = descriptorBytes.length;
+
+        type.addField(FieldSpec.builder(RuntimeClasses.MessageDescriptor, getDescriptorFieldName(message))
+                .addModifiers(Modifier.STATIC, Modifier.FINAL)
+                .initializer("new $T($S, $S, $N, $N, $L, $L)", RuntimeClasses.MessageDescriptor,
+                        message.getFullName(),
+                        msgDesc.getName(),
+                        getFileDescriptorFieldName(),
+                        getDescriptorBytesFieldName(),
+                        offset,
+                        length)
+                .build());
+
+        // Recursively add nested messages
+        for (RequestInfo.MessageInfo nestedType : message.getNestedTypes()) {
+            startOffset = addMessageDescriptor(type, nestedType, startOffset);
+        }
+
+        // Messages should be serialized sequentially, so we start
+        // the next search where the current descriptor ends.
+        return offset + length;
+    }
+
+    private static int findOffset(byte[] data, byte[] part, int start) {
+        // Start search at the start guess
+        for (int i = start; i < data.length; i++) {
+            if (isAtOffset(data, part, i)) {
+                return i;
+            }
+        }
+        // Search before just in case
+        for (int i = 0; i < start; i++) {
+            if (isAtOffset(data, part, i)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("part is not contained inside data");
+    }
+
+    private static boolean isAtOffset(byte[] data, byte[] part, int offset) {
+        for (int i = 0; i < part.length; i++) {
+            if (data[offset + i] != part[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    private CodeBlock generateEmbeddedByteBlock(byte[] descriptor) {
+        // Inspired by Protoc's SharedCodeGenerator::GenerateDescriptors:
+        //
+        // Embed the descriptor.  We simply serialize the entire FileDescriptorProto
+        // and embed it as a string literal, which is parsed and built into real
+        // descriptors at initialization time.  We unfortunately have to put it in
+        // a string literal, not a byte array, because apparently using a literal
+        // byte array causes the Java compiler to generate *instructions* to
+        // initialize each and every byte of the array, e.g. as if you typed:
+        //   b[0] = 123; b[1] = 456; b[2] = 789;
+        // This makes huge bytecode files and can easily hit the compiler's internal
+        // code size limits (error "code to large").  String literals are apparently
+        // embedded raw, which is what we want.
+
+        // Note: Protobuf uses escaped ISO_8859_1 strings, but for now we use Base64
+
+        // Every block of bytes, start a new string literal, in order to avoid the
+        // 64k length limit. Note that this value needs to be <64k.
+        final int charsPerLine = 80; // should be a multiple of 4
+        final int linesPerPart = 20;
+        final int charsPerPart = linesPerPart * charsPerLine;
+        final int bytesPerPart = charsPerPart * 3 / 4; // 3x 8 bit => 4x 6 bit
+
+        // Construct bytes from individual base64 String sections
+        CodeBlock.Builder initBlock = CodeBlock.builder();
+        initBlock.addNamed("$protoUtil:T.decodeBase64(", m).add("$L$>", descriptor.length);
+
+        for (int partIx = 0; partIx < descriptor.length; partIx += bytesPerPart) {
+            byte[] part = Arrays.copyOfRange(descriptor, partIx, Math.min(descriptor.length, partIx + bytesPerPart));
+            String block = Base64.getEncoder().encodeToString(part);
+
+            String line = block.substring(0, Math.min(charsPerLine, block.length()));
+            initBlock.add(",\n$S", line);
+            for (int blockIx = line.length(); blockIx < block.length(); blockIx += charsPerLine) {
+                line = block.substring(blockIx, Math.min(blockIx + charsPerLine, block.length()));
+                initBlock.add(" + \n$S", line);
+            }
+
+        }
+        initBlock.add(")$<");
+
+        return initBlock.build();
+    }
+
+    /**
+     * The Protobuf-Java descriptor does some symbol stripping (e.g. jsonName only appears if it was specified),
+     * so serializing the raw descriptor does not produce binary compatibility. I don't know whether it's worth
+     * implementing it, so for now we leave it empty. See
+     * https://github.com/protocolbuffers/protobuf/blob/209accaf6fb91aa26e6086e73626e1884ddfb737/src/google/protobuf/compiler/retention.cc#L105-L116
+     * Note that this would also need to be stripped from Message descriptors to work with offsets.
+     */
+    private static DescriptorProtos.FileDescriptorProto stripSerializedDescriptor(DescriptorProtos.FileDescriptorProto descriptor) {
+        return descriptor;
+    }
+
+    DescriptorGenerator(RequestInfo.FileInfo info) {
+        m.put("abstractMessage", RuntimeClasses.AbstractMessage);
+        m.put("protoUtil", RuntimeClasses.ProtoUtil);
+        this.info = info;
+        this.fileDescriptorBytes = stripSerializedDescriptor(info.getDescriptor()).toByteArray();
+    }
+
+    final RequestInfo.FileInfo info;
+    final HashMap<String, Object> m = new HashMap<>();
+    final byte[] fileDescriptorBytes;
+
+}

--- a/generator/src/main/java/us/hebi/quickbuf/generator/MessageGenerator.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/MessageGenerator.java
@@ -842,76 +842,14 @@ class MessageGenerator {
     }
 
     private void generateDescriptors(TypeSpec.Builder type) {
-        // Inspired by Protoc's SharedCodeGenerator::GenerateDescriptors:
-        //
-        // Embed the descriptor.  We simply serialize the entire FileDescriptorProto
-        // and embed it as a string literal, which is parsed and built into real
-        // descriptors at initialization time.  We unfortunately have to put it in
-        // a string literal, not a byte array, because apparently using a literal
-        // byte array causes the Java compiler to generate *instructions* to
-        // initialize each and every byte of the array, e.g. as if you typed:
-        //   b[0] = 123; b[1] = 456; b[2] = 789;
-        // This makes huge bytecode files and can easily hit the compiler's internal
-        // code size limits (error "code to large").  String literals are apparently
-        // embedded raw, which is what we want.
-
-        // Note: Protobuf uses escaped ISO_8859_1 strings, but for now we use Base64
-
-        // Every block of bytes, start a new string literal, in order to avoid the
-        // 64k length limit. Note that this value needs to be <64k.
-        final int charsPerLine = 80; // should be a multiple of 4
-        final int linesPerPart = 20;
-        final int charsPerPart = linesPerPart * charsPerLine;
-        final int bytesPerPart = charsPerPart * 3 / 4; // 3x 8 bit => 4x 6 bit
-
-        // Construct bytes from individual base64 String sections
-        final byte[] descriptor = stripSerializedDescriptor(info.getDescriptor()).toByteArray();
-        CodeBlock.Builder initBlock = CodeBlock.builder();
-        initBlock.addNamed("$abstractMessage:T.parseDescriptorBase64(", m).add("$L$>", descriptor.length);
-
-        for (int partIx = 0; partIx < descriptor.length; partIx += bytesPerPart) {
-            byte[] part = Arrays.copyOfRange(descriptor, partIx, Math.min(descriptor.length, partIx + bytesPerPart));
-            String block = Base64.getEncoder().encodeToString(part);
-
-            String line = block.substring(0, Math.min(charsPerLine, block.length()));
-            initBlock.add(",\n$S", line);
-            for (int blockIx = line.length(); blockIx < block.length(); blockIx += charsPerLine) {
-                line = block.substring(blockIx, Math.min(blockIx + charsPerLine, block.length()));
-                initBlock.add(" + \n$S", line);
-            }
-
-        }
-        initBlock.add(")$<");
-
-        // Store the descriptor in a separate class to avoid initializing unused ones
-        String wrapperClassName = "DescriptorHolder";
-        String fieldName = "serializedProtoBytes";
-        TypeSpec descriptorClass = TypeSpec.classBuilder(wrapperClassName)
-                .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                .addField(FieldSpec.builder(RuntimeClasses.BytesType, fieldName)
-                        .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                        .initializer(initBlock.build()).build())
-                .build();
-        type.addType(descriptorClass);
-
-        // Add static access method
-        type.addMethod(MethodSpec.methodBuilder("getDescriptorProtoBytes")
-                .addJavadoc("@return the serialized proto representation of this type's descriptor.")
+        ClassName descriptorClass = info.getParentFile().getOuterClassName();
+        String fieldName = DescriptorGenerator.getDescriptorFieldName(info);
+        type.addMethod(MethodSpec.methodBuilder("getDescriptor")
+                .addJavadoc("@return this type's descriptor.")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(byte[].class)
-                .addStatement("return $L.$L.toArray()", wrapperClassName, fieldName)
+                .returns(RuntimeClasses.MessageDescriptor)
+                .addStatement("return $T.$N", descriptorClass, fieldName)
                 .build());
-
-    }
-
-    /**
-     * The Protobuf-Java descriptor does some symbol stripping (e.g. jsonName only appears if it was specified),
-     * so serializing the raw descriptor does not produce binary compatibility. I don't know whether it's worth
-     * implementing it, so for now we leave it empty. See
-     * https://github.com/protocolbuffers/protobuf/blob/209accaf6fb91aa26e6086e73626e1884ddfb737/src/google/protobuf/compiler/retention.cc#L105-L116
-     */
-    private static DescriptorProtos.DescriptorProto stripSerializedDescriptor(DescriptorProtos.DescriptorProto descriptor) {
-        return descriptor;
     }
 
     MessageGenerator(MessageInfo info) {

--- a/generator/src/main/java/us/hebi/quickbuf/generator/NamingUtil.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/NamingUtil.java
@@ -161,7 +161,7 @@ class NamingUtil {
             "unknown_bytes",// getUnknownFields
             "serialized_size", // getSerializedSize
             "cached_size", // getSerializedSize
-            "descriptor_proto", "descriptor_proto_bytes" // getDescriptorProtoBytes
+            "descriptor" // getDescriptor
     );
 
     private static HashSet<String> withCamelCaseNames(String... fieldNames) {

--- a/generator/src/main/java/us/hebi/quickbuf/generator/RequestInfo.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/RequestInfo.java
@@ -69,6 +69,15 @@ public class RequestInfo {
                 .collect(Collectors.toList());
     }
 
+    public FileInfo getInfoForFile(String fileName) {
+        for (FileInfo file : this.files) {
+            if (file.getFileName().matches(fileName)) {
+                return file;
+            }
+        }
+        throw new IllegalArgumentException("File was not found in this request: " + fileName);
+    }
+
     public boolean shouldEnumUseArrayLookup(int lowestNumber, int highestNumber) {
         return lowestNumber >= 0 && highestNumber < 50; // parameter?
     }
@@ -101,6 +110,7 @@ public class RequestInfo {
 
             DescriptorProtos.FileOptions options = descriptor.getOptions();
             generateMultipleFiles = options.hasJavaMultipleFiles() && options.getJavaMultipleFiles();
+            generateDescriptors = parentRequest.getPluginOptions().isGenerateDescriptors();
             deprecated = options.hasDeprecated() && options.getDeprecated();
 
             // The first message appends a '.', so we omit it to not have two '.' in the default package
@@ -125,6 +135,7 @@ public class RequestInfo {
         private final String baseTypeId;
         private final String fileName;
         private final boolean generateMultipleFiles;
+        private final boolean generateDescriptors;
         private final Map<String, SourceCodeInfo.Location> sourceMap;
 
         private final ClassName outerClassName;
@@ -148,6 +159,7 @@ public class RequestInfo {
             this.typeName = isNested ? parentType.nestedClass(name) : parentType.peerClass(name);
             this.fieldNamesClass = this.typeName.nestedClass("FieldNames");
             this.typeId = parentTypeId + "." + name;
+            this.fullName = typeId.startsWith(".") ? typeId.substring(1) : typeId;
             this.isNested = isNested;
             this.sourceLocation = getParentFile().getSourceLocation(typeId);
         }
@@ -155,6 +167,7 @@ public class RequestInfo {
         private final FileInfo parentFile;
         protected final boolean isNested;
         protected final String typeId;
+        protected final String fullName;
         protected final ClassName typeName;
         protected final ClassName fieldNamesClass;
         private final SourceCodeInfo.Location sourceLocation;

--- a/generator/src/main/java/us/hebi/quickbuf/generator/RuntimeClasses.java
+++ b/generator/src/main/java/us/hebi/quickbuf/generator/RuntimeClasses.java
@@ -48,6 +48,10 @@ class RuntimeClasses {
     static final ClassName FieldName = ClassName.get(API_PACKAGE, "FieldName");
     static final ClassName ProtoEnum = ClassName.get(API_PACKAGE, "ProtoEnum");
     static final ClassName EnumConverter = ProtoEnum.nestedClass("EnumConverter");
+    static final ClassName FileDescriptor = ClassName.get(API_PACKAGE, "Descriptors")
+            .nestedClass("FileDescriptor");
+    static final ClassName MessageDescriptor = ClassName.get(API_PACKAGE, "Descriptors")
+            .nestedClass("Descriptor");
 
     static final String unknownBytesField = "unknownBytes";
     static final String unknownBytesFieldName = "unknownBytesFieldName";

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -60,7 +60,7 @@
             <!-- Add scripts that can be executed by protoc -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-plugin-scripts</id>
@@ -69,7 +69,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <!-- Windows Script-->
                                 <mkdir dir="target"/>
                                 <copy file="src/main/scripts/windows.bat" tofile="target/${protocPluginName}.bat"/>
@@ -81,7 +81,7 @@
                                 <replace file="target/${protocPluginName}" token="{jarfile}" value="${finalName}"/>
                                 <fixcrlf file="target/${protocPluginName}" eol="unix"/>
                                 <chmod file="target/${protocPluginName}" perm="775" type="file"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.22</version>
+                <version>1.18.30</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,19 +168,11 @@
 
     <build>
 
-        <!-- Plugins required for publishing to Maven Central -->
+        <!-- Plugins that run for all modules -->
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>
         </plugins>
 
@@ -300,6 +292,26 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <!-- Plugins required for publishing to Maven Central -->
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>platform-windows</id>
             <activation>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -70,6 +70,7 @@
 
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
 
                     <!-- Replace Java9+ sources with pre-compiled class files -->
@@ -80,9 +81,9 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy file="src/java9/JdkMethods.class" tofile="${project.build.outputDirectory}/us/hebi/quickbuf/JdkMethods.class" overwrite="true" />
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
 
@@ -94,7 +95,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <mkdir dir="${copyToDir}"/>
 
                                 <copy file="${copyFromDir}/RepeatedFloat.java" tofile="${copyToDir}/RepeatedDouble.java" />
@@ -125,7 +126,7 @@
                                     <fileset file="src/test/resources/concat/RepeatedByte.txt" />
                                 </concat>
 
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/runtime/src/main/java/us/hebi/quickbuf/Descriptors.java
+++ b/runtime/src/main/java/us/hebi/quickbuf/Descriptors.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * quickbuf-runtime
+ * %%
+ * Copyright (C) 2019 - 2023 HEBI Robotics
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package us.hebi.quickbuf;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Contains classes that describe the protocol message types.
+ *
+ * @author Florian Enner
+ * @since 20 Sep 2023
+ */
+public final class Descriptors {
+
+
+    public abstract static class GenericDescriptor {
+
+        public byte[] toProtoBytes() {
+            return Arrays.copyOfRange(bytes.array, offset, offset + length);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getFullName() {
+            return fullName;
+        }
+
+        public abstract FileDescriptor getFile();
+
+        // Private constructor to prevent subclasses outside this package
+        private GenericDescriptor(String fullName, String name, RepeatedByte bytes, int offset, int length) {
+            this.fullName = fullName;
+            this.name = name;
+            this.bytes = bytes;
+            this.offset = offset;
+            this.length = length;
+        }
+
+        final String fullName;
+        final String name;
+        final RepeatedByte bytes;
+        final int offset;
+        final int length;
+
+    }
+
+    public static class FileDescriptor extends GenericDescriptor {
+
+        public FileDescriptor(String fileName, String protoPackage, RepeatedByte bytes, FileDescriptor... dependencies) {
+            super(fileName, fileName, bytes, 0, bytes.length());
+            this.protoPackage = protoPackage;
+            this.dependencies = Collections.unmodifiableList(Arrays.asList(dependencies));
+        }
+
+        public List<FileDescriptor> getDependencies() {
+            return dependencies;
+        }
+
+        public String getPackage() {
+            return protoPackage;
+        }
+
+        public FileDescriptor getFile() {
+            return this;
+        }
+
+        final String protoPackage;
+        final List<FileDescriptor> dependencies;
+
+    }
+
+    public static class Descriptor extends GenericDescriptor {
+
+        public Descriptor(String fullName, String name, FileDescriptor file, RepeatedByte bytes, int offset, int length) {
+            super(fullName, name, bytes, offset, length);
+            this.file = file;
+        }
+
+        @Override
+        public FileDescriptor getFile() {
+            return file;
+        }
+
+        final FileDescriptor file;
+
+    }
+
+    private Descriptors(){
+    }
+
+}

--- a/runtime/src/main/java/us/hebi/quickbuf/ProtoMessage.java
+++ b/runtime/src/main/java/us/hebi/quickbuf/ProtoMessage.java
@@ -397,24 +397,6 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     }
 
     /**
-     * Parses descriptor data from a base64 encoded string representation.
-     * Byte arrays are stored very inefficiently in class files, so we
-     * store the binary data in string form and parse it at runtime. String
-     * literals are limited to 64K, so the data may be split into parts.
-     *
-     * @param expectedSize size hint for allocating the initial array
-     * @param parts binary parts encoded as base64 strings. Each part must be shorter than 64K.
-     * @return the byte representation of the descriptor
-     */
-    protected static RepeatedByte parseDescriptorBase64(int expectedSize, String... parts) {
-        RepeatedByte bytes = RepeatedByte.newEmptyInstance().reserve(expectedSize);
-        for (String part : parts) {
-            bytes.addAll(Base64.decode(part));
-        }
-        return bytes;
-    }
-
-    /**
      * @return binary representation of all fields with tags that could not be parsed
      */
     public RepeatedByte getUnknownBytes() {

--- a/runtime/src/main/java/us/hebi/quickbuf/ProtoUtil.java
+++ b/runtime/src/main/java/us/hebi/quickbuf/ProtoUtil.java
@@ -40,6 +40,24 @@ public final class ProtoUtil {
     }
 
     /**
+     * Parses binary data from base64 encoded String segments. Byte arrays are stored very
+     * inefficiently in class files, so it is better to store binary data (e.g. descriptors)
+     * in string form and parse it at runtime. String literals are limited to 64K,
+     * so the data may be split into multiple parts.
+     *
+     * @param expectedSize size hint for allocating the initial array
+     * @param parts binary parts encoded as base64 strings
+     * @return the byte representation of the descriptor
+     */
+    public static RepeatedByte decodeBase64(int expectedSize, String... parts) {
+        RepeatedByte bytes = RepeatedByte.newEmptyInstance().reserve(expectedSize);
+        for (String part : parts) {
+            bytes.addAll(Base64.decode(part));
+        }
+        return bytes;
+    }
+
+    /**
      * Hash code for JSON field name lookup. Any changes need to be
      * synchronized between FieldUtil::hash32 and ProtoUtil::hash32.
      */

--- a/runtime/src/test/java/us/hebi/quickbuf/CompatibilityTest.java
+++ b/runtime/src/test/java/us/hebi/quickbuf/CompatibilityTest.java
@@ -20,10 +20,9 @@
 
 package us.hebi.quickbuf;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
+import com.google.protobuf.*;
 import com.google.protobuf.util.JsonFormat;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -85,6 +84,10 @@ public class CompatibilityTest {
 
     public static byte[] getDescriptorBytes() {
         return TestAllTypes.getDescriptor().toProto().toByteArray();
+    }
+
+    public static Descriptors.Descriptor getTestAllDescriptor() {
+        return TestAllTypes.getDescriptor();
     }
 
     public static String printDescriptor(byte[] bytes) {

--- a/runtime/src/test/java/us/hebi/quickbuf/ProtoTests.java
+++ b/runtime/src/test/java/us/hebi/quickbuf/ProtoTests.java
@@ -933,7 +933,7 @@ public class ProtoTests {
 
     @Test
     public void testDescriptorContent() throws IOException {
-        byte[] bytes = LazyMessage.NestedMessage.getDescriptorProtoBytes();
+        byte[] bytes = LazyMessage.NestedMessage.getDescriptor().toProtoBytes();
         String content = CompatibilityTest.printDescriptor(bytes);
         assertEquals("" +
                 "name: \"NestedMessage\"\n" +
@@ -952,13 +952,21 @@ public class ProtoTests {
                 "  type_name: \".quickbuf_unittest.LazyMessage\"\n" +
                 "  json_name: \"recursiveMessage\"\n" +
                 "}\n", content);
+
+        assertEquals(CompatibilityTest.getTestAllDescriptor().getFullName(), TestAllTypes.getDescriptor().getFullName());
+        assertEquals(CompatibilityTest.getTestAllDescriptor().getName(), TestAllTypes.getDescriptor().getName());
+
+        assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getFullName(), TestAllTypes.getDescriptor().getFile().getFullName());
+        assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getName(), TestAllTypes.getDescriptor().getFile().getName());
+        assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getPackage(), TestAllTypes.getDescriptor().getFile().getPackage());
+
     }
 
     @Ignore // Protobuf-java does some symbol stripping, so it's not equivalent
     @Test
     public void testDescriptorBinaryForm() throws IOException {
         byte[] expected = CompatibilityTest.getDescriptorBytes();
-        byte[] actual = TestAllTypes.getDescriptorProtoBytes();
+        byte[] actual = TestAllTypes.getDescriptor().toProtoBytes();
 
         // Compare string representations to check what fields are different
         assertEquals("Descriptor content",

--- a/runtime/src/test/java/us/hebi/quickbuf/ProtoTests.java
+++ b/runtime/src/test/java/us/hebi/quickbuf/ProtoTests.java
@@ -36,6 +36,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -959,7 +961,35 @@ public class ProtoTests {
         assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getFullName(), TestAllTypes.getDescriptor().getFile().getFullName());
         assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getName(), TestAllTypes.getDescriptor().getFile().getName());
         assertEquals(CompatibilityTest.getTestAllDescriptor().getFile().getPackage(), TestAllTypes.getDescriptor().getFile().getPackage());
+    }
 
+    @Test
+    public void testDescriptorContainedTypeMap() throws IOException {
+        Map<String, Descriptors.Descriptor> map = new HashMap<>();
+        for (Descriptors.FileDescriptor file : TestAllTypes.getDescriptor().getFile().getDependencies()) {
+            for (Descriptors.Descriptor type : file.getAllContainedTypes()) {
+                map.put(type.getFullName(), type);
+            }
+        }
+        for (Descriptors.Descriptor type : TestAllTypes.getDescriptor().getFile().getAllContainedTypes()) {
+            map.put(type.getFullName(), type);
+        }
+        map.values().forEach(val-> System.out.println(val.getFullName()));
+
+        assertEquals(13, map.size());
+        assertEquals(ForeignMessage.getDescriptor(), map.get(ForeignMessage.getDescriptor().getFullName()));
+        assertEquals(TestAllTypes.getDescriptor(), map.get(TestAllTypes.getDescriptor().getFullName()));
+    }
+
+    @Test
+    public void testDescriptorKnownTypeMap() throws IOException {
+        Map<String, Descriptors.Descriptor> map = new HashMap<>();
+        for (Descriptors.Descriptor type : TestAllTypes.getDescriptor().getFile().getAllKnownTypes()) {
+            map.put(type.getFullName(), type);
+        }
+        assertEquals(13, map.size());
+        assertEquals(ForeignMessage.getDescriptor(), map.get(ForeignMessage.getDescriptor().getFullName()));
+        assertEquals(TestAllTypes.getDescriptor(), map.get(TestAllTypes.getDescriptor().getFullName()));
     }
 
     @Ignore // Protobuf-java does some symbol stripping, so it's not equivalent

--- a/runtime/src/test/resources/protos/unittest_all_types.proto
+++ b/runtime/src/test/resources/protos/unittest_all_types.proto
@@ -154,7 +154,7 @@ message TestAllTypes { // comment post message
   optional double missing_fields = 302;
   optional double unknown_bytes = 303;
   optional double quick = 304;
-  optional string descriptor_proto = 305;
+  // optional string descriptor = 305; // Note: this actually breaks protobuf-java
 
   // Collisions with inherited methods
   optional double class = 310;


### PR DESCRIPTION
Added descriptors for #55. New public API:

```Java
class SomeGeneratedMessage extends ProtoMessage {
  public static Descriptor getDescriptor();
} 

interface Descriptor {
  FileDescriptor getFile();
  String getName();
  String getFullName();
  byte[] toProtoBytes();
}

interface FileDescriptor {
  String getName();
  String getFullName();
  String getPackage();
  byte[] toProtoBytes();
  List<FileDescriptor> getDependencies();
  List<Descriptor> getAllContainedTypes(); // everything that is in this file
  List<Descriptor> getAllKnownTypes(); // all types from this file and all dependencies
}
```

The PR also removes the recently added `SomeGeneratedMessage::getDescriptorProtoBytes`. The feature was experimental and didn't work as intended.